### PR TITLE
replaced text_area with editor for monospace font

### DIFF
--- a/src/zcl_axage_demo1_ui.clas.abap
+++ b/src/zcl_axage_demo1_ui.clas.abap
@@ -7,7 +7,6 @@ CLASS zcl_axage_demo1_ui DEFINITION
     INTERFACES z2ui5_if_app.
 
     DATA command TYPE string.
-    DATA objxml TYPE string.
     DATA results TYPE string.
     DATA help TYPE string.
   PROTECTED SECTION.
@@ -99,11 +98,7 @@ CLASS zcl_axage_demo1_ui IMPLEMENTATION.
       command = 'MAP'.
       init_game(  ).
       help = engine->interprete( 'HELP' )->get( ).
-      CALL TRANSFORMATION id SOURCE oref = engine
-                           RESULT XML objxml.
-    ELSE.
-      CALL TRANSFORMATION id SOURCE XML objxml
-                           RESULT oref = engine.
+
     ENDIF.
 
 
@@ -122,9 +117,6 @@ CLASS zcl_axage_demo1_ui IMPLEMENTATION.
       WHEN 'BACK'.
         client->nav_app_leave( client->get_app( client->get( )-id_prev_app_stack  ) ).
     ENDCASE.
-
-    CALL TRANSFORMATION id SOURCE oref = engine
-                         RESULT XML objxml.
 
     DATA(view) = z2ui5_cl_xml_view=>factory( )->shell( ).
     DATA(page) = view->page(
@@ -148,14 +140,11 @@ CLASS zcl_axage_demo1_ui IMPLEMENTATION.
             )->input( client->_bind( command )
             )->button(
                 text  = 'Execute Command'
-                press = client->_event( 'BUTTON_POST' )
-            )->input(
-               value = client->_bind( objxml )
+                press = client->_event( 'BUTTON_POST' ) ).
 
-    ).
     page->grid( 'L8 M8 S8' )->content( 'layout' ).
     grid->simple_form( title = 'Game Console' editable = abap_true )->content( 'form'
-        )->text_area( value = client->_bind( results ) editable = 'false' growingmaxlines = '40' growing = abap_True
+        )->code_editor( value = client->_bind( results ) editable = 'false' type = `plain_text`
                       height = '600px'
         )->text_area( value = client->_bind( help ) editable = 'false' growingmaxlines = '40' growing = abap_True
                       height = '600px'


### PR DESCRIPTION
Hi Thomas,

great example! With the game engine of [Enno](https://github.com/Ennowulff) i have now a lot of new ideas how to use abap2UI5 😀

A small PR just in case if you are interested:
- replaced the left text area with an editor control, the monospace font helps that the map is visualized correctly
- the framework is doing its own transformation with `heap-or-create` so also all attributes of the app instance are serialized automatically. You can save a few lines of code and a little bit of traffic and skip the extra serialization of the engine object
(https://github.com/oblomov-dev/abap2UI5/blob/main/src/z2ui5_cl_http_handler.clas.locals_imp.abap#L348)

<img width="500" alt="image" src="https://github.com/jung-thomas/axage_example/assets/102328295/8afbd0e2-1751-4d08-978e-994e697c00fc">

Best regards!
